### PR TITLE
Ensure the quad event is always emitted on the stream of the match method.

### DIFF
--- a/lib/StreamingStore.ts
+++ b/lib/StreamingStore.ts
@@ -75,6 +75,11 @@ implements RDF.Source<Q>, RDF.Sink<RDF.Stream<Q>, EventEmitter> {
         quad.graph,
       )) {
         for (const pendingStream of this.pendingStreams.getPendingStreamsForQuad(quad)) {
+          /**
+           * The pendingStream emits 'quad' events even before it is initialized.
+           * This allows us to detect when matching quads are added to the store,
+           * without having to consume the stream returned by the `match` method.
+           */
           pendingStream.emit('quad', quad);
           if ((<any> pendingStream).isInitialized) {
             pendingStream.push(quad);

--- a/lib/StreamingStore.ts
+++ b/lib/StreamingStore.ts
@@ -29,7 +29,7 @@ implements RDF.Source<Q>, RDF.Sink<RDF.Stream<Q>, EventEmitter> {
   protected ended = false;
 
   public constructor(store: RDF.Store<Q> = new Store<Q>()) {
-    this.store = <S>store;
+    this.store = <S> store;
   }
 
   /**
@@ -57,7 +57,7 @@ implements RDF.Source<Q>, RDF.Sink<RDF.Stream<Q>, EventEmitter> {
       )) {
         for (const pendingStream of this.pendingStreams.getPendingStreamsForQuad(quad)) {
           pendingStream.emit('quad', quad);
-          if ((<any>pendingStream).isInitialized) {
+          if ((<any> pendingStream).isInitialized) {
             pendingStream.push(quad);
           }
         }
@@ -101,7 +101,7 @@ implements RDF.Source<Q>, RDF.Sink<RDF.Stream<Q>, EventEmitter> {
       pendingStream.on('quad', quad => {
         stream.emit('quad', quad);
       });
-      (<any>stream)._pipeSource = storeResult;
+      (<any> stream)._pipeSource = storeResult;
 
       // This is an ugly hack to annotate pendingStream with the isInitialized once the store stream started being read.
       // This is necessary to avoid duplicate quads cases where match() is called but not yet read, an import is done,

--- a/lib/StreamingStore.ts
+++ b/lib/StreamingStore.ts
@@ -96,7 +96,6 @@ implements RDF.Source<Q>, RDF.Sink<RDF.Stream<Q>, EventEmitter> {
       // The new pendingStream remains open, until the store is ended.
       const pendingStream = new PassThrough({ objectMode: true });
       this.pendingStreams.addPatternListener(pendingStream, subject, predicate, object, graph);
-
       stream = Readable.from(StreamingStore.concatStreams([ storeResult, pendingStream ]));
       pendingStream.on('quad', quad => {
         stream.emit('quad', quad);
@@ -109,7 +108,7 @@ implements RDF.Source<Q>, RDF.Sink<RDF.Stream<Q>, EventEmitter> {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       const readOld = storeResult._read;
       storeResult._read = (size: number) => {
-        (<any>pendingStream).isInitialized = true;
+        (<any> pendingStream).isInitialized = true;
         readOld.call(storeResult, size);
       };
     }


### PR DESCRIPTION
Ensure the quad event is always emitted on the stream returned by the match method.